### PR TITLE
Exlusion of .github, .vscode and **/target/** directories added into Apache Rat configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,9 @@
                                 <exclude>**/META-INF/services/</exclude>
                                 <exclude>**/NOTICES</exclude>
                                 <exclude>**/.gitignore</exclude>
+                                <exclude>**/target/**</exclude>
+                                <exclude>.vscode/**</exclude>
+                                <exclude>.github/**/*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
This few lines prevents Rat from sniffing GitHub actions and vscode directories, also excludes any 'target' directory from being checked - this must help with false positives on module checks.