### PR TITLE
Updated jackson to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Common lib versions -->
         <activation.version>1.2.2</activation.version>
-        <jackson.version>2.12.3</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <jaxb.version>2.3.1</jaxb.version>
 
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
Updated jackson version to 2.13.1, due to [Snyk report](https://snyk.io/vuln/maven:com.fasterxml.jackson.core:jackson-databind@2.12.3) depicting DoS vulnerability. Version 2.13.1 may not be the final solution, but at the moment it has no confirmed vulnerabilities, and it's better to stay on safe side anyway.